### PR TITLE
tree page updates and adding the cell taxon card

### DIFF
--- a/src/app/components/celltaxon_card.yaml
+++ b/src/app/components/celltaxon_card.yaml
@@ -1,0 +1,77 @@
+
+#EntityView:
+id: ui:1
+name: CellTaxon_card
+slug: celltaxon
+description: a view of a cell taxon
+boxes:
+  - box:
+    slug: summarybox
+    id: ui:2
+    name: Summary
+    cardtype: card
+    box_header:
+      key: id
+    sparql_query: |-
+        PREFIX NIMP: <http://example.org/NIMP/>
+                PREFIX prov: <http://www.w3.org/ns/prov#>
+                PREFIX biolink: <https://w3id.org/biolink/vocab/>
+                
+                SELECT DISTINCT ?subject ?predicate ?object ?category_type
+                WHERE {
+                GRAPH <http://hmbataxonomy20250927.com/> {
+                  {  BIND(<{0}> AS ?id)
+                      ?subject ?predicate ?id . }
+                      UNION
+                      { BIND(<{0}> AS ?id)
+                      ?id ?predicate ?object . }
+                      UNION
+                      { BIND(<{0}> AS ?id)
+                      ?subject ?id ?object . }
+                      
+                      OPTIONAL {
+                      ?id prov:wasDerivedFrom ?derivedFrom .
+                      ?derivedFrom biolink:category ?category_type .
+                      }
+                  }
+              }
+    # description: 
+    # Cell taxon. TODO: add description.
+    # box_additional_info:
+    #   properties:
+    #   - key: local_name
+    #     sqrl_query: "TODO (SELECT local_name FROM library_aliquot WHERE library_aliquot_id = 1)"
+    #   - key: category
+    #     sqrl_query: "TODO: query"
+  # - box:
+  #   id: ui:3
+  #   name: DonorBox
+  #   slug: donorbox
+  #   cardtype: card
+  #   box_header:
+  #     key: Donor
+  #   description:  A person or organism that is the source of a biological sample for scientific study.
+  #   box_additional_info:
+  #     header: List of donors
+  #     is_iterable: true
+  #     properties:
+  #     - key: local_name
+  #       sqrl_query: "TODO (SELECT local_name FROM library_aliquot WHERE library_aliquot_id = 1)"
+  #     - key: age_of_death
+  #       sqrl_query: "TODO: query"
+  # - box:
+  #   id: ui:4
+  #   name: TissueSample
+  #   slug: tissuesample
+  #   cardtype: cardtable
+  #   box_header:
+  #     key: TissueSample
+  #   description:  A person or organism that is the source of a biological sample for scientific study.
+  #   box_additional_info:
+  #     header: List of donors
+  #     is_iterable: true
+  #     properties:
+  #     - key: local_name
+  #       sqrl_query: "TODO (SELECT local_name FROM library_aliquot WHERE library_aliquot_id = 1)"
+  #     - key: age_of_death
+  #       sqrl_query: "TODO: query"

--- a/src/app/components/enititycardmapper.yaml
+++ b/src/app/components/enititycardmapper.yaml
@@ -10,4 +10,7 @@ EntityViewCardsMaper:
   - card: resource_card
     slug: "resource" #this should match the one from the config-knowledgebases.yaml
     filename: "resource.yaml"
-     
+
+  - card: CellTaxon_card
+    slug: "celltaxon" # for now it is only used in hmba-taxonomy/pages.tsx
+    filename: "celltaxon_card.yaml"

--- a/src/app/hmba-taxonomy/node/[id]/page.tsx
+++ b/src/app/hmba-taxonomy/node/[id]/page.tsx
@@ -120,35 +120,118 @@ export default function NodeDetailPage() {
             </div>
           </div>
 
-          {/* Metadata Section */}
-          <div className="px-6 py-8">
-            <h3 className="text-lg font-semibold text-gray-900 mb-6">Metadata</h3>
-            
-            {nodeData.meta && Object.keys(nodeData.meta).length > 0 ? (
-              <div className="grid gap-4">
-                {Object.entries(nodeData.meta).map(([key, value]) => (
-                  <div key={key} className="flex flex-col sm:flex-row sm:items-center py-3 border-b border-gray-100 last:border-b-0">
-                    <div className="w-full sm:w-1/3 mb-2 sm:mb-0">
-                      <span className="text-sm font-medium text-gray-500 uppercase tracking-wide">
-                        {key}
-                      </span>
-                    </div>
-                    <div className="w-full sm:w-2/3">
-                      <span className="text-gray-900">
-                        {value !== null && value !== undefined ? String(value) : 'N/A'}
-                      </span>
-                    </div>
-                  </div>
-                ))}
+          {/* Node Information Section */}
+          <div className="px-6 py-8 space-y-8">
+            {/* Accession ID */}
+            {nodeData.accession_id && (
+              <div>
+                <p className="text-lg font-semibold text-gray-900">
+                  <a 
+                    href="https://brain-bican.github.io/models/accession_id/" 
+                    target="_blank" 
+                    rel="noopener noreferrer"
+                    className="underline"
+                    style={{ color: '#00416a' }}
+                    onMouseEnter={(e) => e.target.style.color = '#005a8a'}
+                    onMouseLeave={(e) => e.target.style.color = '#00416a'}
+                  >
+                    Accession ID:
+                  </a> <span className="font-mono">{nodeData.accession_id}</span>
+                </p>
               </div>
-            ) : (
-              <div className="text-center py-8">
-                <div className="text-gray-400 mb-2">
-                  <svg className="mx-auto h-12 w-12" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-                  </svg>
+            )}
+
+            {/* Parent */}
+            {nodeData.parent && (
+              <div>
+                <p className="text-lg font-semibold text-gray-900">
+                  <span style={{ color: '#00416a' }}>Parent:</span> <span className="font-medium">{nodeData.parent}</span>
+                </p>
+              </div>
+            )}
+
+            {/* Abbreviations */}
+            {nodeData.abbreviations && Array.isArray(nodeData.abbreviations) && nodeData.abbreviations.length > 0 && (
+              <div>
+                <h4 className="text-lg font-semibold mb-3">
+                  <a 
+                    href="https://brain-bican.github.io/models/has_abbreviation/" 
+                    target="_blank" 
+                    rel="noopener noreferrer"
+                    className="underline"
+                    style={{ color: '#00416a' }}
+                    onMouseEnter={(e) => e.target.style.color = '#005a8a'}
+                    onMouseLeave={(e) => e.target.style.color = '#00416a'}
+                  >
+                    Abbreviations:
+                  </a>
+                </h4>
+                <div className="space-y-4">
+                  {nodeData.abbreviations.map((abbr: any, index: number) => (
+                    <div key={index} className="space-y-1">
+                      <p className="font-bold text-gray-900">{abbr.term}</p>
+                      {abbr.denotes && abbr.denotes.length > 0 && (
+                        <p className="text-sm text-gray-600">
+                          <a 
+                            href="https://brain-bican.github.io/models/denotes_parcellation_term/" 
+                            target="_blank" 
+                            rel="noopener noreferrer"
+                            className="underline"
+                            style={{ color: '#00416a' }}
+                            onMouseEnter={(e) => e.target.style.color = '#005a8a'}
+                            onMouseLeave={(e) => e.target.style.color = '#00416a'}
+                          >
+                            Denotes:
+                          </a>{' '}
+                          {abbr.denotes.map((denote: string, idx: number) => {
+                            const isUrl = denote.startsWith('http');
+                            return (
+                              <span key={idx}>
+                                {isUrl ? (
+                                  <a 
+                                    href={denote} 
+                                    target="_blank" 
+                                    rel="noopener noreferrer"
+                                    className="text-blue-600 hover:text-blue-800 underline"
+                                  >
+                                    {denote.split('/').pop()}
+                                  </a>
+                                ) : (
+                                  denote
+                                )}
+                                {idx < abbr.denotes.length - 1 && ', '}
+                              </span>
+                            );
+                          })}
+                        </p>
+                      )}
+                      {abbr.meaning && (
+                        <p className="text-sm text-gray-600">
+                          <a 
+                            href="https://brain-bican.github.io/models/meaning/" 
+                            target="_blank" 
+                            rel="noopener noreferrer"
+                            className="underline"
+                            style={{ color: '#00416a' }}
+                            onMouseEnter={(e) => e.target.style.color = '#005a8a'}
+                            onMouseLeave={(e) => e.target.style.color = '#00416a'}
+                          >
+                            Meaning:
+                          </a> {abbr.meaning}
+                        </p>
+                      )}
+                    </div>
+                  ))}
                 </div>
-                <p className="text-gray-500">No metadata available for this node</p>
+              </div>
+            )}
+
+            {/* Belongs to Set */}
+            {nodeData.belongs_to_set && (
+              <div>
+                <p className="text-lg font-semibold text-gray-900">
+                  <span style={{ color: '#00416a' }}>Belongs to Set:</span> <span className="font-mono">{nodeData.belongs_to_set}</span>
+                </p>
               </div>
             )}
           </div>

--- a/src/app/hmba-taxonomy/node/[id]/page.tsx
+++ b/src/app/hmba-taxonomy/node/[id]/page.tsx
@@ -1,0 +1,171 @@
+'use client';
+
+import { useParams, useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+type NodeMeta = Record<string, string | number | boolean | null | undefined>;
+
+interface NodeData {
+  name: string;
+  meta?: NodeMeta;
+  nodeColor?: string;
+}
+
+export default function NodeDetailPage() {
+  const params = useParams();
+  const router = useRouter();
+  const [nodeData, setNodeData] = useState<NodeData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchNodeData = async () => {
+      try {
+        setLoading(true);
+        
+        // Get the node ID from URL params
+        const nodeId = params.id as string;
+        
+        if (!nodeId) {
+          setError('No node ID provided');
+          return;
+        }
+
+        // For now, we'll decode the data from the URL parameter
+        // In a real app, you might fetch this from an API
+        try {
+          const decodedData = JSON.parse(decodeURIComponent(nodeId));
+          setNodeData(decodedData);
+        } catch (parseError) {
+          setError('Invalid node data');
+        }
+      } catch (err) {
+        setError('Failed to load node data');
+        console.error('Error loading node data:', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchNodeData();
+  }, [params.id]);
+
+  const handleBackClick = () => {
+    router.back();
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4"></div>
+          <p className="text-gray-600">Loading node details...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !nodeData) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="text-center">
+          <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
+            <p className="font-bold">Error</p>
+            <p>{error || 'Node not found'}</p>
+          </div>
+          <button
+            onClick={handleBackClick}
+            className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+          >
+            Go Back
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      {/* Header */}
+      <div className="bg-white shadow-sm border-b">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex items-center justify-between h-16">
+            <div className="flex items-center">
+              <button
+                onClick={handleBackClick}
+                className="mr-4 p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100"
+                title="Go back"
+              >
+                <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+                </svg>
+              </button>
+              <h1 className="text-2xl font-bold text-gray-900">Node Details</h1>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Main Content */}
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="bg-white shadow rounded-lg">
+          {/* Node Name Section */}
+          <div className="px-6 py-8 border-b border-gray-200">
+            <div className="flex items-center">
+              <div 
+                className="w-8 h-8 rounded-full mr-4 flex-shrink-0"
+                style={{ backgroundColor: nodeData.nodeColor || 'lightgray' }}
+              ></div>
+              <h2 className="text-3xl font-bold text-gray-900">{nodeData.name}</h2>
+            </div>
+          </div>
+
+          {/* Metadata Section */}
+          <div className="px-6 py-8">
+            <h3 className="text-lg font-semibold text-gray-900 mb-6">Metadata</h3>
+            
+            {nodeData.meta && Object.keys(nodeData.meta).length > 0 ? (
+              <div className="grid gap-4">
+                {Object.entries(nodeData.meta).map(([key, value]) => (
+                  <div key={key} className="flex flex-col sm:flex-row sm:items-center py-3 border-b border-gray-100 last:border-b-0">
+                    <div className="w-full sm:w-1/3 mb-2 sm:mb-0">
+                      <span className="text-sm font-medium text-gray-500 uppercase tracking-wide">
+                        {key}
+                      </span>
+                    </div>
+                    <div className="w-full sm:w-2/3">
+                      <span className="text-gray-900">
+                        {value !== null && value !== undefined ? String(value) : 'N/A'}
+                      </span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="text-center py-8">
+                <div className="text-gray-400 mb-2">
+                  <svg className="mx-auto h-12 w-12" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                  </svg>
+                </div>
+                <p className="text-gray-500">No metadata available for this node</p>
+              </div>
+            )}
+          </div>
+
+          {/* Actions Section */}
+          <div className="px-6 py-4 bg-gray-50 rounded-b-lg">
+            <div className="flex justify-end">
+              <button
+                onClick={handleBackClick}
+                className="bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded-md transition-colors"
+              >
+                Back to Taxonomy
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/hmba-taxonomy/page.tsx
+++ b/src/app/hmba-taxonomy/page.tsx
@@ -184,11 +184,9 @@ const renderCustomNode = ({ nodeDatum, toggleNode }: any) => {
     e.stopPropagation(); // Prevent triggering the node toggle
     console.log('Name clicked:', nodeDatum.name);
 
-    // TODO: this has to be changed to bican id
-    // Use accession_id as the identifier, fallback to name if no accession_id
-    const identifier = nodeDatum.accession_id || nodeDatum.name;
+    const identifier = nodeDatum.id;
 
-    // Navigate to the detail page using the knowledge base approach
+    // Navigate to the detail page from the  knowledge-base section
     router.push(`/knowledge-base/celltaxon/${encodeURIComponent(identifier)}`);
   };
 

--- a/src/app/hmba-taxonomy/page.tsx
+++ b/src/app/hmba-taxonomy/page.tsx
@@ -350,17 +350,27 @@ const renderCustomNode = ({ nodeDatum, toggleNode }: any) => {
         style={{ left, top }}  // HOVER: Apply calculated position to tooltip
       >
         <div className="mb-1 font-semibold">{hoverNode.name || '(root)'}</div>  {/* HOVER: Display hovered node's name */}
-        {meta ? (
-          <div className="space-y-0.5">
-            {Object.entries(meta).map(([k, v]) => (
-              <div key={k} className="flex gap-2">
-                <span className="opacity-70">{k}:</span>
-                <span className="font-medium">{String(v)}</span>
-              </div>
-            ))}
+        
+        {/* Display accession_id prominently if available */}
+        {hoverNode.accession_id && (
+          <div className="mb-2 p-2 bg-blue-50 rounded border-l-2 border-blue-400">
+            <div className="flex gap-2">
+              <span className="opacity-70 text-xs font-medium uppercase tracking-wide">Accession ID:</span>
+              <span className="font-mono text-xs font-semibold text-blue-700">{hoverNode.accession_id}</span>
+            </div>
           </div>
-        ) : (
-          <div className="opacity-70">No metadata</div>
+        )}
+        
+        {/* Display abbreviations if available */}
+        {hoverNode.abbreviations && Array.isArray(hoverNode.abbreviations) && hoverNode.abbreviations.length > 0 && (
+          <div className="mb-2 p-2 bg-green-50 rounded border-l-2 border-green-400">
+            <div className="flex gap-2">
+              <span className="opacity-70 text-xs font-medium uppercase tracking-wide">Abbreviations:</span>
+              <span className="text-xs font-semibold text-green-700">
+                {hoverNode.abbreviations.map((abbr: any) => abbr.term).join(', ')}
+              </span>
+            </div>
+          </div>
         )}
       </div>
     );

--- a/src/app/hmba-taxonomy/page.tsx
+++ b/src/app/hmba-taxonomy/page.tsx
@@ -184,20 +184,12 @@ const renderCustomNode = ({ nodeDatum, toggleNode }: any) => {
     e.stopPropagation(); // Prevent triggering the node toggle
     console.log('Name clicked:', nodeDatum.name);
 
-    // Encode the node data to pass it to the detail page
-    const nodeData = {
-      name: nodeDatum.name,
-      meta: nodeDatum.meta,
-      nodeColor: nodeDatum.nodeColor,
-      accession_id: nodeDatum.accession_id,
-      abbreviations: nodeDatum.abbreviations,
-      parent: nodeDatum.parent,
-      belongs_to_set: nodeDatum.belongs_to_set
-    };
+    // TODO: this has to be changed to bican id
+    // Use accession_id as the identifier, fallback to name if no accession_id
+    const identifier = nodeDatum.accession_id || nodeDatum.name;
 
-    // Navigate to the detail page with the node data as a URL parameter
-    const encodedData = encodeURIComponent(JSON.stringify(nodeData));
-    router.push(`/hmba-taxonomy/node/${encodedData}`);
+    // Navigate to the detail page using the knowledge base approach
+    router.push(`/knowledge-base/celltaxon/${encodeURIComponent(identifier)}`);
   };
 
   return (

--- a/src/app/hmba-taxonomy/page.tsx
+++ b/src/app/hmba-taxonomy/page.tsx
@@ -188,7 +188,11 @@ const renderCustomNode = ({ nodeDatum, toggleNode }: any) => {
     const nodeData = {
       name: nodeDatum.name,
       meta: nodeDatum.meta,
-      nodeColor: nodeDatum.nodeColor
+      nodeColor: nodeDatum.nodeColor,
+      accession_id: nodeDatum.accession_id,
+      abbreviations: nodeDatum.abbreviations,
+      parent: nodeDatum.parent,
+      belongs_to_set: nodeDatum.belongs_to_set
     };
 
     // Navigate to the detail page with the node data as a URL parameter

--- a/src/app/hmba-taxonomy/page.tsx
+++ b/src/app/hmba-taxonomy/page.tsx
@@ -211,7 +211,7 @@ const renderCustomNode = ({ nodeDatum, toggleNode }: any) => {
     >
     {/* Circle */}
     <circle
-      r={15}
+      r={35}
       fill={nodeDatum.nodeColor || 'lightgray'}
       stroke="#1f2937"
       strokeWidth={1.25}
@@ -224,6 +224,11 @@ const renderCustomNode = ({ nodeDatum, toggleNode }: any) => {
       {(() => {
         const name = nodeDatum.name;
         const maxLength = 12; // Maximum characters per line
+
+        // Don't show text for root node
+        if (name === 'root') {
+          return null;
+        }
 
         if (name.length <= maxLength) {
           // Single line for short names

--- a/src/app/hmba-taxonomy/page.tsx
+++ b/src/app/hmba-taxonomy/page.tsx
@@ -2,12 +2,14 @@
 
 import dynamic from 'next/dynamic';
 import React, { useEffect, useRef, useState, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
 
 const Tree = dynamic(() => import('react-d3-tree').then(m => m.Tree), { ssr: false });
 
 type NodeMeta = Record<string, string | number | boolean | null | undefined>;
 
 export default function HMBATaxonomyPage() {
+  const router = useRouter();
   const [data, setData] = useState<any>(null);
 
   // Fullscreen container + size
@@ -177,14 +179,32 @@ export default function HMBATaxonomyPage() {
   );
 
 // Custom node renderer - HOVER INTERACTIONS
-const renderCustomNode = ({ nodeDatum, toggleNode }: any) => (
-  <g
-    onClick={toggleNode}
-    onMouseEnter={() => setHoverNode(nodeDatum)}  // HOVER: Show tooltip when mouse enters node
-    onMouseLeave={() => setHoverNode(null)}       // HOVER: Hide tooltip when mouse leaves node
-    onMouseMove={updateMouse}                     // HOVER: Track mouse position for tooltip placement
-    cursor="pointer"
-  >
+const renderCustomNode = ({ nodeDatum, toggleNode }: any) => {
+  const handleNameClick = (e: React.MouseEvent) => {
+    e.stopPropagation(); // Prevent triggering the node toggle
+    console.log('Name clicked:', nodeDatum.name);
+
+    // Encode the node data to pass it to the detail page
+    const nodeData = {
+      name: nodeDatum.name,
+      meta: nodeDatum.meta,
+      nodeColor: nodeDatum.nodeColor
+    };
+
+    // Navigate to the detail page with the node data as a URL parameter
+    const encodedData = encodeURIComponent(JSON.stringify(nodeData));
+    router.push(`/hmba-taxonomy/node/${encodedData}`);
+  };
+
+  return (
+    <g
+      onClick={toggleNode}
+      // COMMENTED OUT: Hover on node itself
+      // onMouseEnter={() => setHoverNode(nodeDatum)}  // HOVER: Show tooltip when mouse enters node
+      // onMouseLeave={() => setHoverNode(null)}       // HOVER: Hide tooltip when mouse leaves node
+      // onMouseMove={updateMouse}                     // HOVER: Track mouse position for tooltip placement
+      cursor="pointer"
+    >
     {/* Circle */}
     <circle
       r={15}
@@ -208,13 +228,17 @@ const renderCustomNode = ({ nodeDatum, toggleNode }: any) => (
               x={0}
               dy={25 / zoom}
               textAnchor="middle"
+              onClick={handleNameClick}
+              onMouseEnter={() => setHoverNode(nodeDatum)}  // HOVER: Show tooltip when mouse enters text
+              onMouseLeave={() => setHoverNode(null)}       // HOVER: Hide tooltip when mouse leaves text
+              onMouseMove={updateMouse}                     // HOVER: Track mouse position for tooltip placement
               style={{
-                pointerEvents: 'none',
                 fontSize: '60px',
                 fill: 'black',
                 paintOrder: 'stroke',
                 stroke: 'white',
                 strokeWidth: 3,
+                cursor: 'pointer',
               }}
             >
               {name}
@@ -256,13 +280,17 @@ const renderCustomNode = ({ nodeDatum, toggleNode }: any) => (
                 x={0}
                 dy={20 / zoom}
                 textAnchor="middle"
+                onClick={handleNameClick}
+                onMouseEnter={() => setHoverNode(nodeDatum)}  // HOVER: Show tooltip when mouse enters text
+                onMouseLeave={() => setHoverNode(null)}       // HOVER: Hide tooltip when mouse leaves text
+                onMouseMove={updateMouse}                     // HOVER: Track mouse position for tooltip placement
                 style={{
-                  pointerEvents: 'none',
                   fontSize: '60px',
                   fill: 'black',
                   paintOrder: 'stroke',
                   stroke: 'white',
                   strokeWidth: 3,
+                  cursor: 'pointer',
                 }}
               >
                 {line1}
@@ -271,13 +299,17 @@ const renderCustomNode = ({ nodeDatum, toggleNode }: any) => (
                 x={0}
                 dy={32 / zoom}
                 textAnchor="middle"
+                onClick={handleNameClick}
+                onMouseEnter={() => setHoverNode(nodeDatum)}  // HOVER: Show tooltip when mouse enters text
+                onMouseLeave={() => setHoverNode(null)}       // HOVER: Hide tooltip when mouse leaves text
+                onMouseMove={updateMouse}                     // HOVER: Track mouse position for tooltip placement
                 style={{
-                  pointerEvents: 'none',
                   fontSize: '60px',
                   fill: 'black',
                   paintOrder: 'stroke',
                   stroke: 'white',
                   strokeWidth: 3,
+                  cursor: 'pointer',
                 }}
               >
                 {line2}
@@ -297,7 +329,8 @@ const renderCustomNode = ({ nodeDatum, toggleNode }: any) => (
         : ''}
     </title>
   </g>
-);
+  );
+};
 
   const Tooltip = () => {  // HOVER: Tooltip component that appears on hover
     if (!hoverNode) return null;  // HOVER: Only show if a node is being hovered


### PR DESCRIPTION
This pr has updates to the main `hmba-taxonomy` page, but also includes adding a card view with more details.

Initially I was using a specific page for taxons [src/app/hmba-taxonomy/node/[id]/page.tsx](https://github.com/puja-trivedi/brainkb-ui/compare/hmba_taxonomy_ui...djarecka:puja_hmba_taxonomy?expand=1#diff-f5554a1230c5f5a0305775d05902fe9aaf00b6bfd970139f084c1ab07b7b2432) 

Later we moved to use the layout from `knowledge-base/[slug]/[id]`.

I have not removed `src/app/hmba-taxonomy/node/[id]/page.tsx` yest, since we might want to reuse some components in the template